### PR TITLE
Correct nav bar query selector after recent AWS console updates

### DIFF
--- a/main.js
+++ b/main.js
@@ -30,5 +30,5 @@ chrome.storage.local.get(region, (results)=>{
     if(color===undefined){
         return;
     }
-    document.querySelector("#awsc-navigation-container>div").style.backgroundColor=color;
+    document.querySelector("[aria-label='Navigation bar']").style.backgroundColor=color;
 })


### PR DESCRIPTION
This fixes the issue with the navbar extension not working after recent updates as described in https://github.com/corollari/aws-color-region-navbar-extension/issues/2

It highlights the entire nav bar like this: 
![image](https://user-images.githubusercontent.com/701900/146038633-095cfb65-0374-4ddc-ba92-1d4c74af5466.png)

I've tested it in both Firefox and Chrome locally and both appear to work as expected.


