### PR TITLE
Updated the target document selector to work with the new AWS console.

### DIFF
--- a/main.js
+++ b/main.js
@@ -30,5 +30,5 @@ chrome.storage.local.get(region, (results)=>{
     if(color===undefined){
         return;
     }
-    document.querySelector("#awsc-nav-header > nav > nav").style.backgroundColor=color;
+    document.querySelector("#awsc-top-level-nav").style.backgroundColor=color;
 })

--- a/main.js
+++ b/main.js
@@ -30,5 +30,5 @@ chrome.storage.local.get(region, (results)=>{
     if(color===undefined){
         return;
     }
-    document.querySelector("#awsc-navigation-container>div").style.backgroundColor=color;
+    document.querySelector("#awsc-nav-header > nav > nav").style.backgroundColor=color;
 })

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "AWS Navbar Region Color",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Change AWS's navbar color depending on the region",
 	"manifest_version": 2,
 	"browser_action": {


### PR DESCRIPTION
AWS changed the nav header a while back. Confirmed that it works again in Chrome.